### PR TITLE
fix: 适配 CAZ v1.0.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,5 @@
 // @ts-check
 
-// !!! Sharing the dependencies of caz
-module.paths = require.main.paths
-
 const path = require('path')
 const chalk = require('chalk')
 const { name, version } = require('./package.json')

--- a/package.json
+++ b/package.json
@@ -38,8 +38,11 @@
       "template"
     ]
   },
+  "dependencies": {
+    "chalk": "^4.1.2"
+  },
   "devDependencies": {
-    "caz": "0.8.0",
+    "caz": "1.0.0",
     "jest": "27.2.1",
     "standard": "16.0.3"
   }


### PR DESCRIPTION
- caz v1.0.0 版本开始自动安装模板的生产依赖项，且不可再共享主模块的依赖

Fixes zce/caz#96